### PR TITLE
fix: fixing github repo link

### DIFF
--- a/dist/popup.html
+++ b/dist/popup.html
@@ -197,7 +197,7 @@
     </div>
     <div class="error-message" id="errorMessage"></div>
     <div class="footer">
-      <p>This is not an official product of Cursor. It is a personal <a href="https://github.com/" target="_blank">GitHub</a> project.</p>
+      <p>This is not an official product of Cursor. It is a personal <a id="githubLink" href="https://github.com/g-guerzoni/cursor-request-counter-browser-extension" target="_blank">GitHub</a> project.</p>
     </div>
   </div>
   <script src="popup.js"></script>

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -104,6 +104,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (elements.refreshButton) {
         elements.refreshButton.addEventListener("click", () => fetchStats(elements));
     }
-    // Fetch fresh stats immediately
+    document.getElementById('githubLink')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        if (e.target instanceof HTMLAnchorElement) {
+            chrome.tabs.create({ url: e.target.href });
+        }
+    });
     await fetchStats(elements);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-request-counter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Track Cursor.com API usage statistics",
   "scripts": {
     "clean": "rm -rf dist/*",

--- a/src/popup.html
+++ b/src/popup.html
@@ -197,7 +197,7 @@
     </div>
     <div class="error-message" id="errorMessage"></div>
     <div class="footer">
-      <p>This is not an official product of Cursor. It is a personal <a href="https://github.com/g-guerzoni/cursor-request-counter-browser-extension" target="_blank">GitHub</a> project.</p>
+      <p>This is not an official product of Cursor. It is a personal <a id="githubLink" href="https://github.com/g-guerzoni/cursor-request-counter-browser-extension" target="_blank">GitHub</a> project.</p>
     </div>
   </div>
   <script src="popup.js"></script>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -130,6 +130,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     elements.refreshButton.addEventListener("click", () => fetchStats(elements));
   }
 
-  // Fetch fresh stats immediately
+  document.getElementById('githubLink')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    if (e.target instanceof HTMLAnchorElement) {
+      chrome.tabs.create({ url: e.target.href });
+    }
+  });
+
   await fetchStats(elements);
 });


### PR DESCRIPTION
Chrome extensions run in their own isolated context for security reasons. By using chrome.tabs.create(), we explicitly tell Chrome to open the link in a new tab with the complete URL.